### PR TITLE
Loosen up activesupport version requirement for upcoming release

### DIFF
--- a/nextcloud.gemspec
+++ b/nextcloud.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", "~> 5.1"
+  spec.add_runtime_dependency "activesupport", ">= 5.1", "<= 6.1"
   spec.add_runtime_dependency "json", "~> 2.1"
   spec.add_runtime_dependency "nokogiri", "~> 1.8"
   spec.add_runtime_dependency "net-http-report", "~> 0.1"


### PR DESCRIPTION
The new version 6 of the activesupport gem will be coming out soon with Rails 6 and therefore would suggest already loosening up this gem version requirements to match version 5.1 up to and including 6.1.

The reason why I also included version 6.1 (and not only 6.0) of activesupport is because this enables Rails developers to use your nextcloud gem with the master branch of Rails 6 which is currently at version 6.1.0.alpha.

I tested your gem with the master branch of Rails and hence with activesupport 6.1.0alpha and it works fine without any further modifications of your gem.

Thank you very much in advance for considering this PR.