### PR TITLE
Save share URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in nextcloud.gemspec
 gemspec
 
+gem "pry"
+gem "pry-byebug"
 gem "coveralls", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in nextcloud.gemspec
 gemspec
 
+gem "coveralls", require: false
 gem "pry"
 gem "pry-byebug"
-gem "coveralls", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,8 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.3.0)
+    byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     coveralls (0.8.21)
       json (>= 1.8, < 3)
@@ -34,6 +36,7 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
+    method_source (1.0.0)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
     net-http-report (0.2.0)
@@ -44,6 +47,12 @@ GEM
     parser (2.4.0.2)
       ast (~> 2.3)
     powerpack (0.1.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (3.0.1)
     racc (1.5.2)
     rainbow (2.2.2)
@@ -97,6 +106,8 @@ DEPENDENCIES
   bundler (~> 1.16)
   coveralls
   nextcloud!
+  pry
+  pry-byebug
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 0.51)
@@ -104,4 +115,4 @@ DEPENDENCIES
   webmock (~> 3.1)
 
 BUNDLED WITH
-   1.16.0
+   1.17.3

--- a/lib/nextcloud/ocs/file_sharing_api.rb
+++ b/lib/nextcloud/ocs/file_sharing_api.rb
@@ -74,7 +74,7 @@ module Nextcloud
       #   8 delete
       #  16 share, 31 all rights. Value should be one of previously listed.
       # @return [Object] Instance including meta response and share URL if any
-      def create(path, shareType, shareWith=nil, publicUpload=nil, password=nil, permissions=nil)
+      def create(path, shareType, shareWith = nil, publicUpload = nil, password = nil, permissions = nil)
         args = local_variables.reduce({}) { |c, i| c[i] = binding.local_variable_get(i); c }
         response = request(:post, "/shares", args)
         @share_url = response.xpath("//url").text

--- a/lib/nextcloud/ocs/file_sharing_api.rb
+++ b/lib/nextcloud/ocs/file_sharing_api.rb
@@ -10,6 +10,7 @@ module Nextcloud
       include Helpers
 
       attr_accessor :meta
+      attr_reader :share_url
 
       # Initializes API with user credentials
       #
@@ -72,10 +73,11 @@ module Nextcloud
       # @param permissions [Integer,nil] Sets permissions on a resource. 1 gives read rights, 2 update, 4 create,
       #   8 delete
       #  16 share, 31 all rights. Value should be one of previously listed.
-      # @return [Object] Instance including meta response
+      # @return [Object] Instance including meta response and share URL if any
       def create(path, shareType, shareWith=nil, publicUpload=nil, password=nil, permissions=nil)
         args = local_variables.reduce({}) { |c, i| c[i] = binding.local_variable_get(i); c }
         response = request(:post, "/shares", args)
+        @share_url = response.xpath("//url").text
         (@meta = get_meta(response)) && self
       end
 

--- a/lib/nextcloud/ocs/group_folder.rb
+++ b/lib/nextcloud/ocs/group_folder.rb
@@ -40,9 +40,9 @@ module Nextcloud
       def get_folder_id(name)
         response = request(:get, "folders")
         h = doc_to_hash(response, "//data").try(:[], "data").try(:[], "element")
-        group = h.select {|folder| folder["mount_point"] == name }&.first
+        group = h.select { |folder| folder["mount_point"] == name }&.first
         unless group.nil?
-          return group['id']
+          return group["id"]
         end
       end
 
@@ -74,7 +74,7 @@ module Nextcloud
       def destroy(folderid)
         response = request(:delete, "folders/#{folderid}")
         h = doc_to_hash(response, "//data").try(:[], "data")
-        return h == '1'
+        return h == "1"
       end
 
       # Give a group access to a folder
@@ -86,7 +86,7 @@ module Nextcloud
         args = local_variables.reduce({}) { |c, i| c[i] = binding.local_variable_get(i); c }
         response = request(:post, "folders/#{folderid}/groups", args)
         h = doc_to_hash(response, "//data").try(:[], "data")
-        return h == '1'
+        return h == "1"
       end
 
       # Remove access from a group to a folder
@@ -96,7 +96,7 @@ module Nextcloud
       def remove_access(folderid, group)
         response = request(:delete, "folders/#{folderid}/groups/#{group}")
         h = doc_to_hash(response, "//data").try(:[], "data")
-        return h == '1'
+        return h == "1"
       end
 
       # Set the permissions a group has in a folder
@@ -105,7 +105,7 @@ module Nextcloud
       #   PERMISSION_UPDATE = 2;
       #   PERMISSION_DELETE = 8;
       #   PERMISSION_SHARE = 16;
-	    #   PERMISSION_ALL = 31;
+      #   PERMISSION_ALL = 31;
       #
       # @param folderid [Integer] FolderId to modify
       # @param group [String] Group for which the permissions should be changed
@@ -115,19 +115,19 @@ module Nextcloud
         args = local_variables.reduce({}) { |c, i| c[i] = binding.local_variable_get(i); c }
         response = request(:post, "folders/#{folderid}/groups/#{group}", args)
         h = doc_to_hash(response, "//data").try(:[], "data")
-        return h == '1'
+        return h == "1"
       end
 
       # Set the quota for a folder
       #
       # @param folderid [Integer] FolderId to modify
-      # @param quota [Integer] The new quota for the folder in bytes, use -3 for unlimited 
+      # @param quota [Integer] The new quota for the folder in bytes, use -3 for unlimited
       # @return [Bool] True on success
       def set_quota(folderid, quota)
         args = local_variables.reduce({}) { |c, i| c[i] = binding.local_variable_get(i); c }
         response = request(:post, "folders/#{folderid}/quota", args)
         h = doc_to_hash(response, "//data").try(:[], "data")
-        return h == '1'
+        return h == "1"
       end
 
       # Change the name of a folder
@@ -139,7 +139,7 @@ module Nextcloud
         args = local_variables.reduce({}) { |c, i| c[i] = binding.local_variable_get(i); c }
         response = request(:post, "folders/#{folderid}/mountpoint", args)
         h = doc_to_hash(response, "//data").try(:[], "data")
-        return h == '1'
+        return h == "1"
       end
     end
   end

--- a/spec/file_sharing_api_spec.rb
+++ b/spec/file_sharing_api_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe Nextcloud::Ocs::FileSharingApi do
 
   it ".create creates a public link" do
     VCR.use_cassette("file_sharing_api/create-protected-public-link") do
-      @subject.create("/some_file2.txt", 3, nil, nil, "somePassword1_")
+      result = @subject.create("/some_file2.txt", 3, nil, nil, "somePassword1_")
+      expect(result.share_url).to eq("https://cloud.testdomain.com/s/ShXdLVSmHvDF3kS")
       url = @subject.specific("/some_file2.txt")[0]["url"]
       expect(open(url).read).to match("password-protected")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "coveralls"
+require "pry-byebug"
 Coveralls.wear!
 
 require "bundler/setup"


### PR DESCRIPTION
This commit will save the share URL (if any) to `@share_url` on `FileSharingApi`, if the URL is not present on the response body it will be an empty String