### PR TITLE
Fix warning in ruby 2.7

### DIFF
--- a/lib/nextcloud/webdav/directory.rb
+++ b/lib/nextcloud/webdav/directory.rb
@@ -158,7 +158,7 @@ module Nextcloud
 
           if skip_first
             if index == 0
-              @directory = Models::Directory.new(params)
+              @directory = Models::Directory.new(**params)
             else
               @directory.add(params)
             end


### PR DESCRIPTION
Issue: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call This will completely fail for ruby 3.0